### PR TITLE
add PORTAL_AUTH Nuxeo authentication (portal-sso)

### DIFF
--- a/src/Nuxeo/Client/Api/Constants.php
+++ b/src/Nuxeo/Client/Api/Constants.php
@@ -40,5 +40,15 @@ class Constants {
   const ENTITY_TYPE_DOCUMENTS = 'documents';
 
   const ENTITY_TYPE_OPERATION = 'operation';
+  
+  const RANDOM_HEADER = 'NX_RD';
+
+  const TOKEN_SEP = ':';
+
+  const TS_HEADER = 'NX_TS';
+
+  const TOKEN_HEADER = 'NX_TOKEN';
+
+  const USER_HEADER = 'NX_USER';  
 
 }


### PR DESCRIPTION
Hello,

Can you accept my pull-request for PORTAL_AUTH authentication ? please ?

I use a nuxeo server in version 7.10 and i have developed an php application symfony 2.7 with your bundle nuxeo/nuxeo-automation-php-client and on my nuxeo server i have installed the plugin authentication portal-sso (described in this page : https://doc.nuxeo.com/60/nxdoc/authentication/).

On my application i got a trust key. This key is shared on my nuxeo server. This is the PORTAL_AUTH plugin authentication.

My pull request is a code for use this functionnality.

Thanks!

Mathieu HETRU